### PR TITLE
Added support for SSL pem certificate

### DIFF
--- a/unpub/bin/unpub.dart
+++ b/unpub/bin/unpub.dart
@@ -9,12 +9,14 @@ main(List<String> args) async {
   parser.addOption('port', abbr: 'p', defaultsTo: '4000');
   parser.addOption('database',
       abbr: 'd', defaultsTo: 'mongodb://localhost:27017/dart_pub');
+  parser.addOption('pem_path', abbr: 'c', defaultsTo: '');
 
   var results = parser.parse(args);
 
   var host = results['host'] as String;
   var port = int.parse(results['port'] as String);
   var db = results['database'] as String;
+  var pemPath = results['pem_path'] as String;
 
   if (results.rest.isNotEmpty) {
     print('Got unexpected arguments: "${results.rest.join(' ')}".\n\nUsage:\n');
@@ -30,6 +32,7 @@ main(List<String> args) async {
   var app = unpub.App(
     metaStore: mongoStore,
     packageStore: unpub.FileStore(baseDir),
+    pemPath: pemPath,
   );
 
   var server = await app.serve(host, port);

--- a/unpub/lib/src/app.dart
+++ b/unpub/lib/src/app.dart
@@ -27,6 +27,7 @@ class App {
   final String upstream;
   final String googleapisProxy;
   final String overrideUploaderEmail;
+  final String pemPath;
   final Future<void> Function(
       Map<String, dynamic> pubspec, String uploaderEmail) uploadValidator;
 
@@ -37,6 +38,7 @@ class App {
     this.googleapisProxy,
     this.overrideUploaderEmail,
     this.uploadValidator,
+    this.pemPath,
   });
 
   static shelf.Response _okWithJson(Map<String, dynamic> data) =>
@@ -100,7 +102,20 @@ class App {
         return res;
       }
     });
-    var server = await shelf_io.serve(handler, host, port);
+
+    final securityContext = this.pemPath.isNotEmpty
+        ? (SecurityContext()
+          ..useCertificateChain(this.pemPath)
+          ..usePrivateKey(this.pemPath))
+        : null;
+
+    var server = await shelf_io.serve(
+      handler,
+      host,
+      port,
+      securityContext: securityContext,
+    );
+
     return server;
   }
 


### PR DESCRIPTION
The motiviation for this change was to provide a command line option for passing a path to a pem certificate file. This path is used when creating a SecurityContext to pass to the server create call. 
 This now provides the flexibility to create an http or https pub server.