### PR TITLE
chore(deps): mongo_dart 0.4.2

### DIFF
--- a/unpub/pubspec.yaml
+++ b/unpub/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   yaml: ^2.1.15
   pub_semver: ^1.4.2
   json_annotation: ^3.0.0
-  mongo_dart: ^0.3.6
+  mongo_dart: ^0.4.2
   mime: ^0.9.6+3
   intl: ^0.16.0
   path: ^1.6.2


### PR DESCRIPTION
`mongodb+srv://` Urls are accepted from release 0.4.2 using the Db.create() constructor.

https://github.com/mongo-dart/mongo_dart/issues/137