### PR TITLE
Upgrading dependencies, specially mongo_dart

### DIFF
--- a/unpub/README.md
+++ b/unpub/README.md
@@ -9,6 +9,24 @@ Unpub is a self-hosted private Dart Pub server for Enterprise, with a simple web
 
 ![Screenshot](https://raw.githubusercontent.com/bytedance/unpub/master/assets/screenshot.png)
 
+## How to publish a package
+
+1. In the terminal, navigate to your package
+`cd my_package`
+2. Then run this command to publish to unpub
+`flutter pub publish --server {https://myserver.unpub.com}`
+
+## How to receive a package from unpub
+
+In the pubspec.yaml of your project, add the following:
+```
+mypackage:
+  hosted:
+    name: mypackage
+    url: https://myserver.unpub.com
+  version: ^0.0.1
+```
+
 ## Usage via command line
 
 ```sh

--- a/unpub/README.md
+++ b/unpub/README.md
@@ -9,24 +9,6 @@ Unpub is a self-hosted private Dart Pub server for Enterprise, with a simple web
 
 ![Screenshot](https://raw.githubusercontent.com/bytedance/unpub/master/assets/screenshot.png)
 
-## How to publish a package
-
-1. In the terminal, navigate to your package
-`cd my_package`
-2. Then run this command to publish to unpub
-`flutter pub publish --server https://myserver.unpub.com`
-
-## How to receive a package from unpub
-
-In the pubspec.yaml of your project, add the following:
-```
-mypackage:
-  hosted:
-    name: mypackage
-    url: https://myserver.unpub.com
-  version: ^0.0.1
-```
-
 ## Usage via command line
 
 ```sh

--- a/unpub/README.md
+++ b/unpub/README.md
@@ -14,7 +14,7 @@ Unpub is a self-hosted private Dart Pub server for Enterprise, with a simple web
 1. In the terminal, navigate to your package
 `cd my_package`
 2. Then run this command to publish to unpub
-`flutter pub publish --server {https://myserver.unpub.com}`
+`flutter pub publish --server https://myserver.unpub.com`
 
 ## How to receive a package from unpub
 

--- a/unpub/bin/unpub.dart
+++ b/unpub/bin/unpub.dart
@@ -24,7 +24,8 @@ main(List<String> args) async {
 
   var baseDir = path.absolute('unpub-packages');
 
-  var mongoStore = unpub.MongoStore(db);
+  var mongoStore = unpub.MongoStore();
+  await mongoStore.create(db);
   await mongoStore.db.open();
 
   var app = unpub.App(

--- a/unpub/example/main.dart
+++ b/unpub/example/main.dart
@@ -4,7 +4,8 @@ main(List<String> args) async {
   var basedir = '/path/to/basedir'; // Base directory to save pacakges
   var db = 'mongodb://localhost:27017/dart_pub'; // MongoDB uri
 
-  var metaStore = unpub.MongoStore(db);
+  var metaStore = unpub.MongoStore();
+  await metaStore.create(db);
   await metaStore.db.open();
 
   var packageStore = unpub.FileStore(basedir);

--- a/unpub/lib/src/app.dart
+++ b/unpub/lib/src/app.dart
@@ -93,7 +93,7 @@ class App {
         .addHandler((req) async {
       // Return 404 by default
       // https://github.com/google/dart-neats/issues/1
-      var res = await router.handler(req);
+      var res = await router.call(req);
       if (res == null) {
         return shelf.Response.notFound('Not found');
       } else {

--- a/unpub/lib/src/mongo_store.dart
+++ b/unpub/lib/src/mongo_store.dart
@@ -9,10 +9,11 @@ final statsCollection = 'stats';
 class MongoStore extends MetaStore {
   Db db;
 
-  MongoStore(String uri) : db = Db(uri);
   MongoStore.pool(List<String> uris) : db = Db.pool(uris);
 
   SelectorBuilder _selectByName(String name) => where.eq('name', name);
+
+  MongoStore();
 
   @override
   Future<UnpubPackage> queryPackage(String name) async {
@@ -20,6 +21,10 @@ class MongoStore extends MetaStore {
         await db.collection(packageCollection).findOne(_selectByName(name));
     if (json == null) return null;
     return UnpubPackage.fromJson(json);
+  }
+
+  Future<void> create(String uri) async {
+    db = await Db.create(uri);
   }
 
   @override

--- a/unpub/pubspec.yaml
+++ b/unpub/pubspec.yaml
@@ -9,10 +9,10 @@ environment:
 
 dependencies:
   args: ^1.5.1
-  shelf: ^1.1.0
+  shelf: 1.1.0
   shelf_router: ^1.0.0
   http_parser: ^4.0.0
-  http: ^0.13.1
+  http: 0.13.1
   archive: ^3.1.2
   logging: ^1.0.0
   meta: ^1.1.7
@@ -20,7 +20,7 @@ dependencies:
   yaml: ^3.1.0
   pub_semver: ^2.0.0
   json_annotation: ^4.0.0
-  mongo_dart: ^0.7.0
+  mongo_dart: 0.7.0
   mime: ^0.9.6+3
   intl: ^0.16.0
   path: ^1.6.2
@@ -29,9 +29,9 @@ dev_dependencies:
   pedantic: ^1.0.0
   test: ^1.6.1
   build_runner: ^1.0.0
-  json_serializable: ^4.1.0
+  json_serializable: 4.1.0
   collection: ^1.14.11
-  dart_style: ^2.0.0
+  dart_style: 2.0.0
 
 
 executables:

--- a/unpub/pubspec.yaml
+++ b/unpub/pubspec.yaml
@@ -9,18 +9,18 @@ environment:
 
 dependencies:
   args: ^1.5.1
-  shelf: ^0.7.5
-  shelf_router: ^0.7.0
-  http_parser: ^3.1.3
-  http: ^0.12.0
-  archive: ^2.0.8
-  logging: ^0.11.3
+  shelf: ^1.1.0
+  shelf_router: ^1.0.0
+  http_parser: ^4.0.0
+  http: ^0.13.1
+  archive: ^3.1.2
+  logging: ^1.0.0
   meta: ^1.1.7
-  googleapis: ^0.54.0
-  yaml: ^2.1.15
-  pub_semver: ^1.4.2
-  json_annotation: ^3.0.0
-  mongo_dart: ^0.3.6
+  googleapis: ^1.0.0
+  yaml: ^3.1.0
+  pub_semver: ^2.0.0
+  json_annotation: ^4.0.0
+  mongo_dart: ^0.7.0
   mime: ^0.9.6+3
   intl: ^0.16.0
   path: ^1.6.2
@@ -29,10 +29,10 @@ dev_dependencies:
   pedantic: ^1.0.0
   test: ^1.6.1
   build_runner: ^1.0.0
-  json_serializable: ^3.2.3
-  shelf_router_generator: ^0.7.1
+  json_serializable: ^4.1.0
   collection: ^1.14.11
-  dart_style: ^1.2.7
+  dart_style: ^2.0.0
+
 
 executables:
   unpub: unpub

--- a/unpub/test/utils.dart
+++ b/unpub/test/utils.dart
@@ -16,7 +16,8 @@ final email2 = 'email2@example.com';
 final email3 = 'email3@example.com';
 
 createServer(String opEmail) async {
-  var mongoStore = unpub.MongoStore('mongodb://localhost:27017/dart_pub_test');
+  var mongoStore = unpub.MongoStore();
+  await mongoStore.create('mongodb://localhost:27017/dart_pub_test');
   await mongoStore.db.open();
 
   var app = unpub.App(


### PR DESCRIPTION
This PR updates some dependencies. Our main need for this changes was to use mongo_dart in its newest version so we could connect to `mongo+srv://` clusters. 

This version of unpub is already being used in our infrastructure. We have been able to connect to our mongo databases using this url scheme without trouble 🎉 

Kudos to @andrelewkatz for writing these changes 👍 

This fixes #2 