### PR TITLE
 export models so metastore can be subclassed.

### DIFF
--- a/unpub/lib/unpub.dart
+++ b/unpub/lib/unpub.dart
@@ -3,3 +3,4 @@ export 'src/mongo_store.dart';
 export 'src/package_store.dart';
 export 'src/file_store.dart';
 export 'src/app.dart';
+export 'src/models.dart';


### PR DESCRIPTION
 - metastore is already exported by uses classes from models in public api
 - Fixes: bytedance#27

Signed-off-by: Dell Green <dell.green@ideaworks.co.uk>