### PR TITLE
feat: change downloadUrl to future

### DIFF
--- a/unpub/lib/src/app.dart
+++ b/unpub/lib/src/app.dart
@@ -200,7 +200,8 @@ class App {
     }
 
     if (packageStore.supportsDownloadUrl) {
-      return shelf.Response.found(packageStore.downloadUrl(name, version));
+      return shelf.Response.found(
+          await packageStore.downloadUrl(name, version));
     } else {
       return shelf.Response.ok(
         packageStore.download(name, version),

--- a/unpub/lib/src/package_store.dart
+++ b/unpub/lib/src/package_store.dart
@@ -1,7 +1,7 @@
 abstract class PackageStore {
   bool supportsDownloadUrl = false;
 
-  String downloadUrl(String name, String version) {
+  Future<String> downloadUrl(String name, String version) {
     throw 'downloadUri not implemented';
   }
 

--- a/unpub/lib/src/package_store.dart
+++ b/unpub/lib/src/package_store.dart
@@ -1,7 +1,9 @@
+import 'dart:async';
+
 abstract class PackageStore {
   bool supportsDownloadUrl = false;
 
-  Future<String> downloadUrl(String name, String version) {
+  FutureOr<String> downloadUrl(String name, String version) {
     throw 'downloadUri not implemented';
   }
 


### PR DESCRIPTION
If the `downloadUrl` is future, it will be helpful when implementing other package stores.

For example, I am using `gcloud` for package store. 

```dart
  @override
  FutureOr<String> downloadUrl(String name, String version) async {
    var object = await _bucket.info('$name-$version.tar.gz');
    final url = object.downloadLink.toString();
    return url;
  }
```

