### PR TITLE
feat: add json api end-point with versions list

### DIFF
--- a/unpub/lib/src/app.dart
+++ b/unpub/lib/src/app.dart
@@ -426,6 +426,26 @@ class App {
     return _okWithJson({'data': data.toJson()});
   }
 
+  @Route.get('/packages/<name>.json')
+  Future<shelf.Response> getPackageVersions(
+      shelf.Request req, String name) async {
+    var package = await metaStore.queryPackage(name);
+    if (package == null) {
+      return _badRequest('package not exists', status: HttpStatus.notFound);
+    }
+
+    var versions = package.versions.map((v) => v.version).toList();
+    versions.sort((a, b) {
+      return semver.Version.prioritize(
+          semver.Version.parse(b), semver.Version.parse(a));
+    });
+
+    return _okWithJson({
+      'name': name,
+      'versions': versions,
+    });
+  }
+
   @Route.get('/webapi/package/<name>/<version>')
   Future<shelf.Response> getPackageDetail(
       shelf.Request req, String name, String version) async {

--- a/unpub/lib/src/app.g.dart
+++ b/unpub/lib/src/app.g.dart
@@ -21,6 +21,7 @@ Router _$AppRouter(App service) {
   router.add('DELETE', r'/api/packages/<name>/uploaders/<email>',
       service.removeUploader);
   router.add('GET', r'/webapi/packages', service.getPackages);
+  router.add('GET', r'/packages/<name>.json', service.getPackageVersions);
   router.add(
       'GET', r'/webapi/package/<name>/<version>', service.getPackageDetail);
   router.add('GET', r'/', service.indexHtml);


### PR DESCRIPTION
I'm using [melos](https://pub.dev/packages/melos) to manage a multi-package repository -- as part of the `melos publish` process, it retrieves a list of all versions from `https://pub.dev/packages/[package].json` end-point.

This PR adds a new API route `/packages/[package].json` that returns a JSON payload consisting of `name` and a list of `versions` strings -- e.g. https://pub.dev/packages/unpub.json

```json
{
  "name": "unpub",
  "versions": [
    "2.0.0",
    "1.2.2",
    "1.2.1",
    "1.2.0",
    "1.1.0",
    "1.0.0",
    "0.4.0",
    "0.3.0",
    "0.2.2",
    "0.2.1",
    "0.2.0",
    "0.1.2",
    "0.1.1+1",
    "0.1.1",
    "0.1.0",
    "0.0.1"
  ]
}
```