### PR TITLE
Implementing null safety in app.serve

### DIFF
--- a/unpub/bin/unpub.dart
+++ b/unpub/bin/unpub.dart
@@ -14,7 +14,7 @@ main(List<String> args) async {
 
   var results = parser.parse(args);
 
-  var host = results['host'] as String?;
+  var host = results['host'] as String;
   var port = int.parse(results['port'] as String);
   var dbUri = results['database'] as String;
   var proxy_origin = results['proxy-origin'] as String;

--- a/unpub/lib/src/app.dart
+++ b/unpub/lib/src/app.dart
@@ -117,7 +117,7 @@ class App {
     return info.email!;
   }
 
-  Future<HttpServer> serve([String? host = '0.0.0.0', int port = 4000]) async {
+  Future<HttpServer> serve([String host = '0.0.0.0', int port = 4000]) async {
     var handler = const shelf.Pipeline()
         .addMiddleware(corsHeaders())
         .addMiddleware(shelf.logRequests())


### PR DESCRIPTION
In Dart 2.17.6, **_unpub is failing at compilation_**.

/Users/vi/flutter/bin/cache/dart-sdk/bin/dart --enable-asserts /Users/vi/IdeaProjects/unpub/unpub/bin/unpub.dart
lib/src/app.dart:130:48: Error: The argument type 'String?' can't be assigned to the parameter type 'Object' because 'String?' is nullable and 'Object' isn't.
 - 'Object' is from 'dart:core'.
    var server = await shelf_io.serve(handler, host, port);
                                               ^

Process finished with exit code 254

Adding proper null safety in **app.dart** to avoid this failure.