### PR TITLE
feat(infrastructure): add Dockerfile and docker-compose.yaml for Unpub

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+ARG dart_version=2.19.6
+
+FROM dart:${dart_version}
+
+ENV PUB_HOSTED_URL="https://mirrors.tuna.tsinghua.edu.cn/dart-pub"
+
+WORKDIR /app
+
+COPY ./unpub/ ./source
+
+EXPOSE 4000
+
+WORKDIR /app/source
+
+RUN dart pub get && \
+  dart compile aot-snapshot bin/unpub.dart && \
+  cp bin/unpub.aot /app/unpub.aot && \
+  rm -r /app/source
+
+WORKDIR /app
+
+# ENTRYPOINT [ "dart", "run", "bin/unpub.dart", "--database", "mongodb://unpub-mongo-service:27017/dart_pub"]
+ENTRYPOINT [ "dartaotruntime", "unpub.aot", "--database", "mongodb://unpub-mongo-service:27017/dart_pub"]
+
+
+
+

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,32 @@
+# name: unpub2_1-docker
+services:
+  unpub-mongo:
+    image: mongo:5.0.29
+    ports:
+      - "27017:27017"
+    restart: always
+    logging:
+      options:
+        max-size: 10m
+    volumes:
+      - ~/.unpub/mongo:/data/db
+    hostname: unpub-mongo-service
+    domainname: unpub-mongo-service.com
+    # networks:
+    #   - unpub-network
+
+  unpub:
+    build: .
+    ports:
+      - "4000:4000"
+    restart: always
+    depends_on:
+      - unpub-mongo
+    volumes:
+      - ~/.unpub/packages:/app/unpub-packages
+    # networks:
+    #   - unpub-network
+# networks:
+#   unpub-network:
+#     external: true
+#     driver: bridge


### PR DESCRIPTION
- Create Dockerfile to build Unpub container image
- Add docker-compose.yaml to define Unpub and MongoDB services
- Configure environment variables and expose necessary ports
- Set up volume mounts for persistent data storage